### PR TITLE
[workflow] Skip `v2-model-tester` 

### DIFF
--- a/newflow.py
+++ b/newflow.py
@@ -96,9 +96,9 @@ def newpipe():
     )
 
     # test out new model server (via REST API calls), use imported function
-    run_function(
-        "hub://v2-model-tester",
-        name="model-tester",
-        params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
-        inputs={"table": train.outputs["test_set"]},
-    )
+    # run_function(
+    #     "hub://v2-model-tester",
+    #     name="model-tester",
+    #     params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
+    #     inputs={"table": train.outputs["test_set"]},
+    # )

--- a/newflow.py
+++ b/newflow.py
@@ -95,6 +95,7 @@ def newpipe():
         models=[{"key": f"{DATASET}:v1", "model_path": train.outputs["model"]}],
     )
 
+    # TODO: Add the following function once v2-model-tester is fixed
     # test out new model server (via REST API calls), use imported function
     # run_function(
     #     "hub://v2-model-tester",


### PR DESCRIPTION
Following the deprecation of the `ChartArtifact` (https://github.com/mlrun/mlrun/pull/5510), the `v2-model-tester` func is not supported. 
Until we decide either to fix or to remove this func, in this PR we skip that func in the pipeline to avoid unnecessary failures.  