### PR TITLE
[Workflows] Add empty workflow for testing

### DIFF
--- a/empty_workflow.py
+++ b/empty_workflow.py
@@ -3,5 +3,5 @@ from kfp import dsl
 
 @dsl.pipeline(name="test_pipeline", description="empty pipeline")
 def pipeline():
-    dsl.ContainerOp(name="test", image="python:3.9", command=["Testing !"])
+    dsl.ContainerOp(name="test", image="mlrun/mlrun", command=["Testing !"])
 

--- a/empty_workflow.py
+++ b/empty_workflow.py
@@ -1,7 +1,24 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from kfp import dsl
+
+import mlrun
 
 
 @dsl.pipeline(name="test_pipeline", description="empty pipeline")
 def pipeline():
-    dsl.ContainerOp(name="test", image="mlrun/mlrun", command=["Testing !"])
+    ctx = mlrun.get_or_create_ctx("empty-pipeline")
+    ctx.logger.info("Running empty pipeline")
 

--- a/empty_workflow.py
+++ b/empty_workflow.py
@@ -1,0 +1,7 @@
+from kfp import dsl
+
+
+@dsl.pipeline(name="test_pipeline", description="empty pipeline")
+def pipeline():
+    dsl.ContainerOp(name="test", image="python:3.9", command=["Testing !"])
+


### PR DESCRIPTION
This PR introduces an empty pipeline workflow designed specifically for testing purposes. 
The goal is to provide a simple and isolated workflow that can be used to verify if the pipeline runs successfully without relying on the more complex existing workflows that often tied to other files and configurations, which can make testing and debugging more cumbersome.